### PR TITLE
Potential fix for code scanning alert no. 3: Incorrect conversion between integer types

### DIFF
--- a/internal/provider/resource_workflow_job_template_approval_node.go
+++ b/internal/provider/resource_workflow_job_template_approval_node.go
@@ -191,7 +191,7 @@ func (r *WorkflowJobTemplateApprovalNode) Create(ctx context.Context, req resour
 	}
 
 	tempId = fmt.Sprintf("%v", returnedData["id"])
-	tempIdInt, err = strconv.Atoi(tempId)
+	tempIdInt64, err := strconv.ParseInt(tempId, 10, 32)
 	if err != nil {
 		resp.Diagnostics.AddError(
 			"Error converting returned ID to an integer",
@@ -200,7 +200,7 @@ func (r *WorkflowJobTemplateApprovalNode) Create(ctx context.Context, req resour
 		return
 	}
 
-	data.ApprovalTemplateId = types.Int32Value(int32(tempIdInt))
+	data.ApprovalTemplateId = types.Int32Value(int32(tempIdInt64))
 
 	resp.Diagnostics.Append(resp.State.Set(ctx, &data)...)
 }


### PR DESCRIPTION
Potential fix for [https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/3](https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/3)

The best fix is to parse directly into the destination bit size rather than parsing into architecture-sized `int` and narrowing later.

In `internal/provider/resource_workflow_job_template_approval_node.go`, replace the second `strconv.Atoi` flow (the one feeding `ApprovalTemplateId`) with `strconv.ParseInt(..., 10, 32)`, then cast the result to `int32`. This ensures parsing fails if the value is out of `int32` range, eliminating truncation risk without changing intended behavior for valid IDs.

Concretely:
- In the `Create` method, around lines 193–204:
  - Replace:
    - `tempIdInt, err = strconv.Atoi(tempId)`
    - `data.ApprovalTemplateId = types.Int32Value(int32(tempIdInt))`
  - With:
    - `tempIdInt64, err := strconv.ParseInt(tempId, 10, 32)`
    - `data.ApprovalTemplateId = types.Int32Value(int32(tempIdInt64))`
- No new imports are needed (`strconv` is already imported).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
