### PR TITLE
Potential fix for code scanning alert no. 2: Incorrect conversion between integer types

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -252,19 +252,19 @@ func (p *theProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			)
 			return
 		} else if envAPIRetryCountExists && envAPIRetryDelaySecondsExists {
-			retryCountInt, err := strconv.Atoi(envAPIRetryCount)
+			retryCountInt, err := strconv.ParseInt(envAPIRetryCount, 10, 32)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Provider Configuration Error",
-					fmt.Sprintf("AAP_API_RETRY_COUNT must be an integer, got: %s", envAPIRetryCount),
+					fmt.Sprintf("AAP_API_RETRY_COUNT must be a 32-bit integer, got: %s", envAPIRetryCount),
 				)
 				return
 			}
-			retryDelayInt, err := strconv.Atoi(envAPIRetryDelaySeconds)
+			retryDelayInt, err := strconv.ParseInt(envAPIRetryDelaySeconds, 10, 32)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Provider Configuration Error",
-					fmt.Sprintf("AAP_API_RETRY_DELAY_SECONDS must be an integer, got: %s", envAPIRetryDelaySeconds),
+					fmt.Sprintf("AAP_API_RETRY_DELAY_SECONDS must be a 32-bit integer, got: %s", envAPIRetryDelaySeconds),
 				)
 				return
 			}


### PR DESCRIPTION
Potential fix for [https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/2](https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/2)

Use parsing APIs that enforce the intended bit size at parse time, and avoid architecture-dependent intermediate types.

Best fix in this snippet:
- Replace `strconv.Atoi(...)` for retry count and retry delay env vars with `strconv.ParseInt(..., 10, 32)`.
- Keep existing diagnostics behavior, but update integer formatting to use parsed `int64` values cast to `int32` only after successful 32-bit parse.
- This guarantees values outside `int32` range fail parsing and are reported as configuration errors, preserving intended functionality while removing overflow risk.

Edits are in `internal/provider/provider.go`, in the env var parsing block around current lines 255–273. No new imports are needed (`strconv` already present).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
