### PR TITLE
Potential fix for code scanning alert no. 1: Incorrect conversion between integer types

### DIFF
--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -252,7 +252,7 @@ func (p *theProvider) Configure(ctx context.Context, req provider.ConfigureReque
 			)
 			return
 		} else if envAPIRetryCountExists && envAPIRetryDelaySecondsExists {
-			retryCountInt, err := strconv.Atoi(envAPIRetryCount)
+			retryCountInt64, err := strconv.ParseInt(envAPIRetryCount, 10, 32)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Provider Configuration Error",
@@ -260,7 +260,7 @@ func (p *theProvider) Configure(ctx context.Context, req provider.ConfigureReque
 				)
 				return
 			}
-			retryDelayInt, err := strconv.Atoi(envAPIRetryDelaySeconds)
+			retryDelayInt64, err := strconv.ParseInt(envAPIRetryDelaySeconds, 10, 32)
 			if err != nil {
 				resp.Diagnostics.AddError(
 					"Provider Configuration Error",
@@ -268,8 +268,8 @@ func (p *theProvider) Configure(ctx context.Context, req provider.ConfigureReque
 				)
 				return
 			}
-			client.apiRetryCount = int32(retryCountInt)
-			client.apiRetryDelaySeconds = int32(retryDelayInt)
+			client.apiRetryCount = int32(retryCountInt64)
+			client.apiRetryDelaySeconds = int32(retryDelayInt64)
 		}
 	}
 


### PR DESCRIPTION
Potential fix for [https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/1](https://github.com/tfbrew/terraform-provider-aap/security/code-scanning/1)

Use `strconv.ParseInt(..., 10, 32)` for both environment values instead of `strconv.Atoi`, then cast the parsed `int64` to `int32`. This ensures parsing fails if the value is outside the signed 32-bit range, preventing silent truncation/wraparound and preserving intended behavior (emit provider configuration error and return on bad input).

In `internal/provider/provider.go`, update the two parsing statements in the env-var branch:

- Replace:
  - `retryCountInt, err := strconv.Atoi(envAPIRetryCount)`
  - `retryDelayInt, err := strconv.Atoi(envAPIRetryDelaySeconds)`
- With:
  - `retryCountInt64, err := strconv.ParseInt(envAPIRetryCount, 10, 32)`
  - `retryDelayInt64, err := strconv.ParseInt(envAPIRetryDelaySeconds, 10, 32)`

Then assign:

- `client.apiRetryCount = int32(retryCountInt64)`
- `client.apiRetryDelaySeconds = int32(retryDelayInt64)`

No new imports are required (`strconv` is already imported). Error messages can remain as-is (“must be an integer”), since out-of-range values should also be rejected.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
